### PR TITLE
Intl helpers

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": "brightspace/polymer-config"
+  "extends": "brightspace/polymer-config",
+  "globals": {
+    "d2lIntl": false
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bower_components*
 node_modules
 bower-*.json
+package-lock.json

--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,8 @@
   ],
   "dependencies": {
     "app-localize-behavior": "PolymerElements/app-localize-behavior#1 - 2",
-    "polymer": "Polymer/polymer#1.9 - 2"
+    "polymer": "Polymer/polymer#1.9 - 2",
+    "d2l-intl-import": "^1.0.0"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#1 - 2",

--- a/d2l-localize-behavior.html
+++ b/d2l-localize-behavior.html
@@ -1,5 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../app-localize-behavior/app-localize-behavior.html">
+<link rel="import" href="../d2l-intl-import/d2l-intl.html">
 <script>
 	window.D2L = window.D2L || {};
 	window.D2L.PolymerBehaviors = window.D2L.PolymerBehaviors || {};
@@ -46,6 +47,38 @@
 			if (this._observer && this._observer.disconnect) {
 				this._observer.disconnect();
 			}
+		},
+		formatDateTime: function(val, opts) {
+			var formatter = new d2lIntl.DateTimeFormat(this.language, opts);
+			return formatter.format(val);
+		},
+		formatDate: function(val, opts) {
+			var formatter = new d2lIntl.DateTimeFormat(this.language, opts);
+			return formatter.formatDate(val);
+		},
+		formatFileSize: function(val) {
+			var formatter = new d2lIntl.FileSizeFormat(this.language);
+			return formatter.format(val);
+		},
+		formatNumber: function(val, opts) {
+			var formatter = new d2lIntl.NumberFormat(this.language, opts);
+			return formatter.format(val);
+		},
+		formatTime: function(val, opts) {
+			var formatter = new d2lIntl.DateTimeFormat(this.language, opts);
+			return formatter.formatTime(val);
+		},
+		parseDate: function(val) {
+			var parser = new d2lIntl.DateTimeParse(this.language);
+			return parser.parseDate(val);
+		},
+		parseNumber: function(val, opts) {
+			var parser = new d2lIntl.NumberParse(this.language, opts);
+			return parser.parse(val);
+		},
+		parseTime: function(val) {
+			var parser = new d2lIntl.DateTimeParse(this.language);
+			return parser.parseTime(val);
 		},
 		_observer: null,
 		_computeLanguage: function(resources, lang, fallback) {

--- a/test/d2l-localize-behavior.html
+++ b/test/d2l-localize-behavior.html
@@ -21,6 +21,11 @@
 				<test-elem language="fr"></test-elem>
 			</template>
 		</test-fixture>
+		<test-fixture id="en-ca">
+			<template>
+				<test-elem language="en-ca"></test-elem>
+			</template>
+		</test-fixture>
 		<script>
 			describe('d2l-localize-behavior', function() {
 
@@ -167,6 +172,92 @@
 							done();
 						});
 						htmlElem.removeAttribute('data-lang-default');
+					});
+
+				});
+
+				describe('date/time formatting and parsing', function() {
+
+					var date = new Date(2017, 11, 1, 17, 13);
+
+					beforeEach(function() {
+						elem = fixture('en-ca');
+					});
+
+					it('should format a date using default format', function() {
+						var val = elem.formatDate(date);
+						expect(val).to.equal('12/1/2017');
+					});
+
+					it('should format a date using specified format', function() {
+						var val = elem.formatDate(date, {format: 'full'});
+						expect(val).to.equal('Friday, December 1, 2017');
+					});
+
+					it('should format a time using default format', function() {
+						var val = elem.formatTime(date);
+						expect(val).to.equal('5:13 PM');
+					});
+
+					it('should format a time using specified format', function() {
+						var val = elem.formatTime(date, {format: 'full'});
+						expect(val).to.equal('5:13 PM ');
+					});
+
+					it('should format a date/time using default format', function() {
+						var val = elem.formatDateTime(date);
+						expect(val).to.equal('12/1/2017 5:13 PM');
+					});
+
+					it('should format a date/time using specified format', function() {
+						var val = elem.formatDateTime(date, {format: 'medium'});
+						expect(val).to.equal('Dec 1, 2017 5:13 PM');
+					});
+
+					it('should parse a date', function() {
+						var val = elem.parseDate('12/1/2017');
+						expect(val.getFullYear()).to.equal(2017);
+						expect(val.getMonth()).to.equal(11);
+						expect(val.getDate()).to.equal(1);
+					});
+
+					it('should parse a time', function() {
+						var val = elem.parseTime('5:13 PM');
+						expect(val.getHours()).to.equal(17);
+						expect(val.getMinutes()).to.equal(13);
+					});
+
+				});
+
+				describe('number formatting and parsing', function() {
+
+					it('should format a number using default format', function() {
+						var val = elem.formatNumber(1234567.890);
+						expect(val).to.equal('1,234,567.89');
+					});
+
+					it('should format a number rounding up', function() {
+						var val = elem.formatNumber(1234567.890, {maximumFractionDigits: 0});
+						expect(val).to.equal('1,234,568');
+					});
+
+					it('should format a number with specified format', function() {
+						var val = elem.formatNumber(0.189, {style: 'percent'});
+						expect(val).to.equal('18.9 %');
+					});
+
+					it('should parse a number', function() {
+						var val = elem.parseNumber('1234567.890');
+						expect(val).to.equal(1234567.89);
+					});
+
+				});
+
+				describe('file size formatting', function() {
+
+					it('should format a file size', function() {
+						var val = elem.formatFileSize(1234567.89);
+						expect(val).to.equal('1.18 MB')
 					});
 
 				});

--- a/test/d2l-localize-behavior.html
+++ b/test/d2l-localize-behavior.html
@@ -257,7 +257,7 @@
 
 					it('should format a file size', function() {
 						var val = elem.formatFileSize(1234567.89);
-						expect(val).to.equal('1.18 MB')
+						expect(val).to.equal('1.18 MB');
 					});
 
 				});

--- a/test/index.html
+++ b/test/index.html
@@ -8,8 +8,6 @@
 	<body>
 		<script>
 			WCT.loadSuites([
-				'd2l-localize-behavior.html?wc-shadydom=true&wc-ce=true',
-				'd2l-localize-behavior.html?dom=shadow&lazyRegister=true&useNativeCSSProperties=true',
 				'd2l-localize-behavior.html?dom=shadow'
 			]);
 		</script>

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -28,7 +28,7 @@
 				{
 					"browserName": "safari",
 					"platform": "OS X 10.12",
-					"version": "10.0"
+					"version": ""
 				},
 				{
 					"browserName": "microsoftedge",


### PR DESCRIPTION
Exposing a few `d2l-intl` helper functions on `localize-behavior`. They're one step better than calling into `d2l-intl` directly since they'll always apply the language of the current page.

This is just the first step though -- next will be to also apply any user overrides that are in effect, and then after that I'm going to try to call into this stuff from inside the `{date}`, `{time}` and `{number}` types in the ICU Message Syntax. Or if I can't do that, try to create custom `{d2lDate}` types.