### PR TITLE
returning empty string when timezone data is missing

### DIFF
--- a/d2l-localize-behavior.html
+++ b/d2l-localize-behavior.html
@@ -123,6 +123,7 @@
 		},
 		_tryGetTimezone: function() {
 			if (this.__timezone === null) {
+				this.__timezone = '';
 				var htmlElems = window.document.getElementsByTagName('html');
 				if (htmlElems.length === 1 && htmlElems[0].hasAttribute('data-timezone')) {
 					try {
@@ -130,7 +131,7 @@
 							htmlElems[0].getAttribute('data-timezone')
 						).name;
 					} catch (e) {
-						this.__timezone = '';
+						// swallow exception
 					}
 				}
 			}

--- a/test/d2l-localize-behavior.html
+++ b/test/d2l-localize-behavior.html
@@ -212,18 +212,6 @@
 						expect(val).to.equal('5:13 PM Canada - Toronto');
 					});
 
-					it('should not fail if timezone data is missing', function() {
-						htmlElem.removeAttribute('data-timezone');
-						var val = elem.formatTime(date, {format: 'full'});
-						expect(val).to.equal('5:13 PM ');
-					});
-
-					it('should not fail if timezone data is invalid', function() {
-						htmlElem.setAttribute( 'data-timezone', '{ohno;:}' );
-						var val = elem.formatTime(date, {format: 'full'});
-						expect(val).to.equal('5:13 PM ');
-					});
-
 					it('should format a date/time using default format', function() {
 						var val = elem.formatDateTime(date);
 						expect(val).to.equal('12/1/2017 5:13 PM');
@@ -278,6 +266,35 @@
 					it('should format a file size', function() {
 						var val = elem.formatFileSize(1234567.89);
 						expect(val).to.equal('1.18 MB');
+					});
+
+				});
+
+				describe('tryGetTimezone', function() {
+
+					beforeEach(function() {
+						elem = fixture('basic');
+						htmlElem.removeAttribute('data-timezone');
+					});
+
+					it('should return timezone\'s name', function() {
+						htmlElem.setAttribute(
+							'data-timezone',
+							JSON.stringify({ name: 'Hello' })
+						);
+						var timezone = elem._tryGetTimezone();
+						expect(timezone).to.equal('Hello');
+					});
+
+					it('should not fail if timezone data is missing', function() {
+						var timezone = elem._tryGetTimezone();
+						expect(timezone).to.equal('');
+					});
+
+					it('should not fail if timezone data is invalid', function() {
+						htmlElem.setAttribute( 'data-timezone', '{ohno;:}' );
+						var timezone = elem._tryGetTimezone();
+						expect(timezone).to.equal('');
 					});
 
 				});


### PR DESCRIPTION
When timezone data was missing, this was returning `null`. The Intl library still handled it fine, which is why no tests failed. Added some tests specifically for `_tryGetTimezone` to catch this.