### PR TITLE
localize mixin for class-based elements

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,8 @@
 {
   "extends": "brightspace/polymer-config",
+  "env": {
+    "es6": true
+  },
   "globals": {
     "d2lIntl": false
   }

--- a/d2l-localize-mixin.html
+++ b/d2l-localize-mixin.html
@@ -1,0 +1,18 @@
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="d2l-localize-behavior.html">
+
+<script>
+	window.D2L = window.D2L || {};
+	window.D2L.PolymerMixins = window.D2L.PolymerMixins || {};
+
+	/**
+	* @polymerMixin
+	* @appliesMixin D2L.PolymerBehaviors.LocalizeBehavior
+	*/
+	D2L.PolymerMixins.LocalizeMixin = Polymer.dedupingMixin(
+		(base) => class extends Polymer.mixinBehaviors(
+			[D2L.PolymerBehaviors.LocalizeBehavior], base
+		) { }
+	);
+
+</script>

--- a/demo/index.html
+++ b/demo/index.html
@@ -8,6 +8,7 @@
 		<link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
 		<link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
 		<link rel="import" href="behavior-component.html">
+		<link rel="import" href="mixin-component.html">
 		<custom-style>
 			<style is="custom-style" include="demo-pages-shared-styles"></style>
 		</custom-style>
@@ -26,6 +27,14 @@
 			<demo-snippet>
 				<template>
 					<d2l-behavior-component></d2l-behavior-component>
+				</template>
+			</demo-snippet>
+
+
+			<h3>Mixin (Class-based)</h3>
+			<demo-snippet>
+				<template>
+					<d2l-mixin-component></d2l-mixin-component>
 				</template>
 			</demo-snippet>
 

--- a/demo/mixin-component.html
+++ b/demo/mixin-component.html
@@ -1,0 +1,50 @@
+<link rel="import" href="../../polymer/polymer-element.html">
+<link rel="import" href="../d2l-localize-mixin.html">
+
+<dom-module id="d2l-mixin-component">
+	<template strip-whitespace>
+		<style>
+			:host {
+				display: block;
+			}
+		</style>
+		[[localize('hello')]]
+	</template>
+
+	<script>
+		/**
+		* @extends {Polymer.Element}
+		* @appliesMixin D2L.PolymerMixins.LocalizeMixin
+		*/
+		class D2LMixinComponent extends D2L.PolymerMixins.LocalizeMixin(Polymer.Element) {
+			static get is() { return 'd2l-mixin-component'; }
+
+			static get properties() {
+				return {
+					resources: {
+						value: function() {
+							return {
+								'ar': { 'hello': 'مرحبا' },
+								'de': { 'hello': 'Hallo' },
+								'en': { 'hello': 'Hello' },
+								'en-CA': { 'hello': 'Hello, eh' },
+								'es': { 'hello': 'Hola' },
+								'fr': { 'hello': 'Bonjour' },
+								'ja': { 'hello': 'こんにちは' },
+								'ko': { 'hello': '안녕하세요' },
+								'pt-BR': { 'hello': 'Olá' },
+								'sv': { 'hello': 'Hallå' },
+								'tr': { 'hello': 'Merhaba' },
+								'zh-CN': { 'hello': '你好' },
+								'zh-TW': { 'hello': '你好' }
+							};
+						}
+					}
+				};
+			}
+
+		}
+
+		window.customElements.define(D2LMixinComponent.is, D2LMixinComponent);
+	</script>
+</dom-module>


### PR DESCRIPTION
While the mixin included in this PR is functional, it does not include tests.  For the moment, just posting this PR to starting thinking about how localization of text resources should be done in class-based elements.

There is no class-based version of [app-localize-behavior](https://github.com/PolymerElements/app-localize-behavior).  The Polymer 2 docs suggest wrapping the behavior - so this PR adds a mixin that effectively wraps [d2l-localize-behavior](https://github.com/BrightspaceUI/localize-behavior/blob/master/d2l-localize-behavior.html).

Alternatives to wrapping may include:
* implementing our own class mixin in the absence of a Polymer one
* moving to a global localize method approach rather than class mixin

Anyway, I wanted to put this out there to show what wrapping entails.

This would probably best go in it's own repo since:
* while this lints successfully, we should probably be using polymer 2 lint rules in `polymer.json`
* the name of this repo is a little misleading
* it does not make any sense trying to run tests against polymer 1 variant
* running the demo for things like IE11 will require a transpile, probably via `polymer build` - this is something we'll probably need to do for most of our components
* at first I was thinking we could branch for class-based version (which might be ok approach for other components), but this mixin depends on the hybrid `d2l-localize-behavior` so dependency-wise it starts getting a bit messy