### PR TITLE
fix to ensure date/time/number functions render with correct language

### DIFF
--- a/d2l-localize-behavior.html
+++ b/d2l-localize-behavior.html
@@ -8,6 +8,42 @@
 	/** @polymerBehavior D2L.PolymerBehaviors.LocalizeBehaviorImpl */
 	D2L.PolymerBehaviors.LocalizeBehaviorImpl = {
 		properties: {
+			formatDateTime: {
+				type: Function,
+				computed: '_computeFormatDateTime(language, __overrides, __timezone)'
+			},
+			formatDate: {
+				type: Function,
+				computed: '_computeFormatDate(language, __overrides, __timezone)'
+			},
+			formatFileSize: {
+				type: Function,
+				computed: '_computeFormatFileSize(language)'
+			},
+			formatNumber: {
+				type: Function,
+				computed: '_computeFormatNumber(language, __overrides)'
+			},
+			formatTime: {
+				type: Function,
+				computed: '_computeFormatTime(language, __overrides, __timezone)'
+			},
+			language: {
+				type: String,
+				computed: '_computeLanguage(resources, __documentLanguage, __documentLanguageFallback)'
+			},
+			parseDate: {
+				type: Function,
+				computed: '_computeParseDate(language, __overrides)'
+			},
+			parseNumber: {
+				type: Function,
+				computed: '_computeParseNumber(language, __overrides)'
+			},
+			parseTime: {
+				type: Function,
+				computed: '_computeParseTime(language)'
+			},
 			__documentLanguage: {
 				type: String,
 				value: function() {
@@ -24,15 +60,19 @@
 			},
 			__overrides: {
 				type: Object,
-				value: null
+				value: function() {
+					return this._tryParseHtmlElemAttr('data-intl-overrides', {});
+				}
 			},
 			__timezone: {
 				type: String,
-				value: null
+				value: function() {
+					return this._tryParseHtmlElemAttr('data-timezone', {name: ''}).name;
+				}
 			}
 		},
 		observers: [
-			'_computeLanguage( resources, __documentLanguage, __documentLanguageFallback )'
+			'_languageChange(language)'
 		],
 		attached: function() {
 
@@ -45,6 +85,10 @@
 						this.__documentLanguage = htmlElem.getAttribute('lang');
 					} else if (mutation.attributeName === 'data-lang-default') {
 						this.__documentLanguageFallback = htmlElem.getAttribute('data-lang-default');
+					} else if (mutation.attributeName === 'data-intl-overrides') {
+						this.__overrides = this._tryParseHtmlElemAttr('data-intl-overrides', {});
+					} else if (mutation.attributeName === 'data-intl-overrides') {
+						this.__timezone = this._tryParseHtmlElemAttr('data-timezone', {name: ''}).name;
 					}
 				}
 			}.bind(this));
@@ -56,63 +100,79 @@
 				this._observer.disconnect();
 			}
 		},
-		formatDateTime: function(val, opts) {
-			opts = opts || {};
-			opts.locale = this._tryGetOverrides();
-			opts.timezone = opts.timezone || this._tryGetTimezone();
-			var formatter = new d2lIntl.DateTimeFormat(this.language, opts);
-			return formatter.format(val);
+		_computeFormatDateTime: function(language, overrides, timezone) {
+			return function(val, opts) {
+				opts = opts || {};
+				opts.locale = overrides;
+				opts.timezone = opts.timezone || timezone;
+				var formatter = new d2lIntl.DateTimeFormat(language, opts);
+				return formatter.format(val);
+			};
 		},
-		formatDate: function(val, opts) {
-			opts = opts || {};
-			opts.locale = this._tryGetOverrides();
-			opts.timezone = opts.timezone || this._tryGetTimezone();
-			var formatter = new d2lIntl.DateTimeFormat(this.language, opts);
-			return formatter.formatDate(val);
+		_computeFormatDate: function(language, overrides, timezone) {
+			return function(val, opts) {
+				opts = opts || {};
+				opts.locale = overrides;
+				opts.timezone = opts.timezone || timezone;
+				var formatter = new d2lIntl.DateTimeFormat(language, opts);
+				return formatter.formatDate(val);
+			};
 		},
-		formatFileSize: function(val) {
-			var formatter = new d2lIntl.FileSizeFormat(this.language);
-			return formatter.format(val);
+		_computeFormatFileSize: function(language) {
+			return function(val) {
+				var formatter = new d2lIntl.FileSizeFormat(language);
+				return formatter.format(val);
+			};
 		},
-		formatNumber: function(val, opts) {
-			opts = opts || {};
-			opts.locale = this._tryGetOverrides();
-			var formatter = new d2lIntl.NumberFormat(this.language, opts);
-			return formatter.format(val);
+		_computeFormatNumber: function(language, overrides) {
+			return function(val, opts) {
+				opts = opts || {};
+				opts.locale = overrides;
+				var formatter = new d2lIntl.NumberFormat(language, opts);
+				return formatter.format(val);
+			};
 		},
-		formatTime: function(val, opts) {
-			opts = opts || {};
-			opts.locale = this._tryGetOverrides();
-			opts.timezone = opts.timezone || this._tryGetTimezone();
-			var formatter = new d2lIntl.DateTimeFormat(this.language, opts);
-			return formatter.formatTime(val);
+		_computeFormatTime: function(language, overrides, timezone) {
+			return function(val, opts) {
+				opts = opts || {};
+				opts.locale = overrides;
+				opts.timezone = opts.timezone || timezone;
+				var formatter = new d2lIntl.DateTimeFormat(language, opts);
+				return formatter.formatTime(val);
+			};
 		},
-		parseDate: function(val) {
-			var parser = new d2lIntl.DateTimeParse(
-				this.language,
-				{ locale: this._tryGetOverrides() }
-			);
-			return parser.parseDate(val);
+		_computeParseDate: function(language, overrides) {
+			return function(val) {
+				var parser = new d2lIntl.DateTimeParse(
+					language,
+					{ locale: overrides }
+				);
+				return parser.parseDate(val);
+			};
 		},
-		parseNumber: function(val, opts) {
-			opts = opts || {};
-			opts.locale = this._tryGetOverrides();
-			var parser = new d2lIntl.NumberParse(this.language, opts);
-			return parser.parse(val);
+		_computeParseNumber: function(language, overrides) {
+			return function(val, opts) {
+				opts = opts || {};
+				opts.locale = overrides;
+				var parser = new d2lIntl.NumberParse(language, opts);
+				return parser.parse(val);
+			};
 		},
-		parseTime: function(val) {
-			var parser = new d2lIntl.DateTimeParse(this.language);
-			return parser.parseTime(val);
+		_computeParseTime: function(language) {
+			return function(val) {
+				var parser = new d2lIntl.DateTimeParse(language);
+				return parser.parseTime(val);
+			};
 		},
 		_observer: null,
 		_computeLanguage: function(resources, lang, fallback) {
 			var language = this._tryResolve(resources, lang)
 				|| this._tryResolve(resources, fallback)
 				|| this._tryResolve(resources, 'en-us');
-			if (language !== this.language) {
-				this.language = language;
-				this.fire('d2l-localize-behavior-language-changed');
-			}
+			return language;
+		},
+		_languageChange: function() {
+			this.fire('d2l-localize-behavior-language-changed');
 		},
 		_tryResolve: function(resources, val) {
 
@@ -136,21 +196,6 @@
 
 			return null;
 
-		},
-		_tryGetOverrides: function() {
-			if (this.__overrides === null) {
-				this.__overrides = this._tryParseHtmlElemAttr('data-intl-overrides', {});
-			}
-			return this.__overrides;
-		},
-		_tryGetTimezone: function() {
-			if (this.__timezone === null) {
-				this.__timezone = this._tryParseHtmlElemAttr(
-					'data-timezone',
-					{name: ''}
-				).name;
-			}
-			return this.__timezone;
 		},
 		_tryParseHtmlElemAttr: function(attrName, defaultValue) {
 			var htmlElems = window.document.getElementsByTagName('html');

--- a/demo/behavior-component.html
+++ b/demo/behavior-component.html
@@ -2,7 +2,12 @@
 <link rel="import" href="../d2l-localize-behavior.html">
 <dom-module id="d2l-behavior-component">
 	<template strip-whitespace>
-		[[localize('hello')]]
+		<p>Text: [[localize('hello')]]</p>
+		<p>Number: [[formatNumber(123456.789)]]</p>
+		<p>Date: [[formatDate(date)]]</p>
+		<p>Time: [[formatTime(date)]]</p>
+		<p>Date &amp; time: [[formatDateTime(date)]]</p>
+		<p>File size: [[formatFileSize(123456789)]]</p>
 	</template>
 	<script>
 		Polymer({
@@ -11,6 +16,10 @@
 				D2L.PolymerBehaviors.LocalizeBehavior
 			],
 			properties: {
+				date: {
+					type: Date,
+					value: new Date()
+				},
 				resources: {
 					value: function() {
 						return {

--- a/demo/index.html
+++ b/demo/index.html
@@ -23,12 +23,36 @@
 		<div class="vertical-section-container centered">
 
 			<h3>Behavior (Hybrid)</h3>
+			<div style="margin-bottom: 1rem;">
+				<label>Language:
+					<select onchange="updateLang(this);">
+						<option value="ar">Arabic</option>
+						<option value="de">German</option>
+						<option value="en" selected>English</option>
+						<option value="en-CA">English (Canada)</option>
+						<option value="es">Spanish</option>
+						<option value="fr">French</option>
+						<option value="ja">Japanese</option>
+						<option value="ko">Korean</option>
+						<option value="pt-BR">Portuguese</option>
+						<option value="sv">Swedish</option>
+						<option value="tr">Turkish</option>
+						<option value="zh-CN">Chinese (Simplified)</option>
+						<option value="zh-TW">Chinese (Traditional)</option>
+					</select>
+				</label>
+			</div>
 			<demo-snippet>
 				<template>
 					<d2l-behavior-component></d2l-behavior-component>
 				</template>
 			</demo-snippet>
-
 		</div>
+		<script>
+			function updateLang(select) {
+				var value = select.options[select.selectedIndex].value;
+				document.documentElement.setAttribute('lang', value);
+			}
+		</script>
 	</body>
 </html>

--- a/test/d2l-localize-behavior.html
+++ b/test/d2l-localize-behavior.html
@@ -178,12 +178,38 @@
 
 				});
 
+				describe('localize', function() {
+
+					beforeEach(function() {
+						elem = fixture('en-ca');
+					});
+
+					it('should localize text', function() {
+						var val = elem.localize('hello');
+						expect(val).to.equal('Hello');
+					});
+
+					it('should localize text using data binding', function() {
+						expect(elem.$$('.text').innerText).to.equal('Hello');
+					});
+
+					it('should re-localize text when locale changes', function(done) {
+						elem.addEventListener('d2l-localize-behavior-language-changed', function() {
+							expect(elem.$$('.text').innerText).to.equal('Bonjour');
+							done();
+						});
+						htmlElem.setAttribute('lang', 'fr');
+					});
+
+				});
+
 				describe('date/time formatting and parsing', function() {
 
 					var date = new Date(2017, 11, 1, 17, 13);
 
 					beforeEach(function() {
 						elem = fixture('en-ca');
+						elem.date = date;
 					});
 
 					it('should format a date using default format', function() {
@@ -196,6 +222,10 @@
 						expect(val).to.equal('Friday, December 1, 2017');
 					});
 
+					it('should format date via data binding', function() {
+						expect(elem.$$('.date').innerText).to.equal('12/1/2017');
+					});
+
 					it('should format a time using default format', function() {
 						var val = elem.formatTime(date);
 						expect(val).to.equal('5:13 PM');
@@ -206,6 +236,10 @@
 						expect(val).to.equal('5:13 PM ');
 					});
 
+					it('should format time via data binding', function() {
+						expect(elem.$$('.time').innerText).to.equal('5:13 PM');
+					});
+
 					it('should format a date/time using default format', function() {
 						var val = elem.formatDateTime(date);
 						expect(val).to.equal('12/1/2017 5:13 PM');
@@ -214,6 +248,10 @@
 					it('should format a date/time using specified format', function() {
 						var val = elem.formatDateTime(date, {format: 'medium'});
 						expect(val).to.equal('Dec 1, 2017 5:13 PM');
+					});
+
+					it('should format a date/time using data binding', function() {
+						expect(elem.$$('.date-time').innerText).to.equal('12/1/2017 5:13 PM');
 					});
 
 					it('should parse a date', function() {
@@ -248,6 +286,11 @@
 						expect(val).to.equal('18.9 %');
 					});
 
+					it('should format a number using data binding', function() {
+						elem.number = 1234567.890;
+						expect(elem.$$('.number').innerText).to.equal('1,234,567.89');
+					});
+
 					it('should parse a number', function() {
 						var val = elem.parseNumber('1234567.890');
 						expect(val).to.equal(1234567.89);
@@ -260,7 +303,6 @@
 					var date = new Date(2018, 0, 4, 15, 5);
 
 					beforeEach(function() {
-						elem = fixture('en-ca');
 						htmlElem.setAttribute(
 							'data-intl-overrides',
 							JSON.stringify({
@@ -283,6 +325,7 @@
 								}
 							})
 						);
+						elem = fixture('en-ca');
 					});
 
 					it('should format a date using overrides', function() {
@@ -332,33 +375,33 @@
 						expect(val).to.equal('1.18 MB');
 					});
 
+					it('should format a file size using data binding', function() {
+						elem.number = 1234567.89;
+						expect(elem.$$('.file-size').innerText).to.equal('1.18 MB');
+					});
+
 				});
 
-				describe('tryGetTimezone', function() {
-
-					beforeEach(function() {
-						elem = fixture('basic');
-						htmlElem.removeAttribute('data-timezone');
-					});
+				describe('timezone', function() {
 
 					it('should return timezone\'s name', function() {
 						htmlElem.setAttribute(
 							'data-timezone',
 							JSON.stringify({ name: 'Hello' })
 						);
-						var timezone = elem._tryGetTimezone();
-						expect(timezone).to.equal('Hello');
+						elem = fixture('basic');
+						expect(elem.__timezone).to.equal('Hello');
 					});
 
 					it('should not fail if timezone data is missing', function() {
-						var timezone = elem._tryGetTimezone();
-						expect(timezone).to.equal('');
+						elem = fixture('basic');
+						expect(elem.__timezone).to.equal('');
 					});
 
 					it('should not fail if timezone data is invalid', function() {
 						htmlElem.setAttribute('data-timezone', '{ohno;:}');
-						var timezone = elem._tryGetTimezone();
-						expect(timezone).to.equal('');
+						elem = fixture('basic');
+						expect(elem.__timezone).to.equal('');
 					});
 
 				});

--- a/test/test-elem.html
+++ b/test/test-elem.html
@@ -2,7 +2,11 @@
 <link rel="import" href="../d2l-localize-behavior.html">
 <dom-module id="test-elem">
 	<template strip-whitespace>
-		{{localize('hello')}}
+		<p class="text">{{localize('hello')}}</p><p class="number">{{formatNumber(number)}}</p>
+		<p class="date">{{formatDate(date)}}</p>
+		<p class="time">{{formatTime(date)}}</p>
+		<p class="date-time">{{formatDateTime(date)}}</p>
+		<p class="file-size">{{formatFileSize(number)}}</p>
 	</template>
 	<script>
 		Polymer({
@@ -11,6 +15,13 @@
 				D2L.PolymerBehaviors.LocalizeBehavior
 			],
 			properties: {
+				date: {
+					type: Date,
+					value: new Date()
+				},
+				number: {
+					type: Number
+				},
 				resources: {
 					value: function() {
 						return {


### PR DESCRIPTION
Working on the Polymer 3 stuff I found a bug, so fixing in `master` first.

This bug only occurs when you use data-binding date/time/number functions, _not_ by calling the methods directly. E.g. `<p>[[formatDate(date)]]</p>`. That call to `formatDate` happens once _before_ the component is attached when the language hasn't been determined yet, which was rendering the date/time/number and never re-rendering it.

The fix makes the date/time/number functions similar to `localize()` which is a computed function based on the things that could change in the future. When once changes, it re-renders.