### PR TITLE
expose timezone identifier

### DIFF
--- a/d2l-localize-behavior.html
+++ b/d2l-localize-behavior.html
@@ -72,7 +72,7 @@
 			},
 			timezoneIdentifier: {
 				type: String,
-				value: function () {
+				value: function() {
 					return this._tryParseHtmlElemAttr('data-timezone', { identifier: '' }).identifier;
 				}
 			}
@@ -95,8 +95,8 @@
 					} else if (mutation.attributeName === 'data-intl-overrides') {
 						this.__overrides = this._tryParseHtmlElemAttr('data-intl-overrides', {});
 					} else if (mutation.attributeName === 'data-timezone') {
-						this.__timezone = this._tryParseHtmlElemAttr('data-timezone', {name: ''}).name;
 						this.timezoneIdentifier = this._tryParseHtmlElemAttr('data-timezone', { identifier: '' }).identifier;
+						this.__timezone = this._tryParseHtmlElemAttr('data-timezone', {name: ''}).name;
 					}
 				}
 			}.bind(this));

--- a/d2l-localize-behavior.html
+++ b/d2l-localize-behavior.html
@@ -64,22 +64,20 @@
 					return this._tryParseHtmlElemAttr('data-intl-overrides', {});
 				}
 			},
-			__timezone: {
-				type: String,
+			__timezoneObject: {
+				type: Object,
 				value: function() {
-					return this._tryParseHtmlElemAttr('data-timezone', {name: ''}).name;
+					return this._tryParseHtmlElemAttr('data-timezone', { name: '', identifier: '' });
 				}
 			},
-			timezoneIdentifier: {
+			__timezone: {
 				type: String,
-				value: function() {
-					return this._tryParseHtmlElemAttr('data-timezone', { identifier: '' }).identifier;
-				}
+				computed: '_computeTimezone(__timezoneObject)'
 			}
 		},
 		observers: [
 			'_languageChange(language)',
-			'_timezoneChange(__timezone)',
+			'_timezoneChange(__timezoneObject)',
 		],
 		attached: function() {
 
@@ -95,8 +93,7 @@
 					} else if (mutation.attributeName === 'data-intl-overrides') {
 						this.__overrides = this._tryParseHtmlElemAttr('data-intl-overrides', {});
 					} else if (mutation.attributeName === 'data-timezone') {
-						this.timezoneIdentifier = this._tryParseHtmlElemAttr('data-timezone', { identifier: '' }).identifier;
-						this.__timezone = this._tryParseHtmlElemAttr('data-timezone', {name: ''}).name;
+						this.__timezoneObject = this._tryParseHtmlElemAttr('data-timezone', { name: '', identifier: '' });
 					}
 				}
 			}.bind(this));
@@ -107,6 +104,12 @@
 			if (this._observer && this._observer.disconnect) {
 				this._observer.disconnect();
 			}
+		},
+		getTimezone: function() {
+			return this.__timezoneObject;
+		},
+		_computeTimezone: function(timezoneObject) {
+			return timezoneObject && timezoneObject.name;
 		},
 		_computeFormatDateTime: function(language, overrides, timezone) {
 			return function(val, opts) {

--- a/d2l-localize-behavior.html
+++ b/d2l-localize-behavior.html
@@ -69,6 +69,12 @@
 				value: function() {
 					return this._tryParseHtmlElemAttr('data-timezone', {name: ''}).name;
 				}
+			},
+			timezoneIdentifier: {
+				type: String,
+				value: function () {
+					return this._tryParseHtmlElemAttr('data-timezone', { identifier: '' }).identifier;
+				}
 			}
 		},
 		observers: [
@@ -90,6 +96,7 @@
 						this.__overrides = this._tryParseHtmlElemAttr('data-intl-overrides', {});
 					} else if (mutation.attributeName === 'data-timezone') {
 						this.__timezone = this._tryParseHtmlElemAttr('data-timezone', {name: ''}).name;
+						this.timezoneIdentifier = this._tryParseHtmlElemAttr('data-timezone', { identifier: '' }).identifier;
 					}
 				}
 			}.bind(this));

--- a/test/d2l-localize-behavior.html
+++ b/test/d2l-localize-behavior.html
@@ -390,7 +390,7 @@
 							JSON.stringify({ name: 'Hello' })
 						);
 						elem = fixture('basic');
-						expect(elem.__timezone).to.equal('Hello');
+						expect(elem.getTimezone().name).to.equal('Hello');
 					});
 
 					it('should return timezone\'s identifier', function() {
@@ -399,27 +399,27 @@
 							JSON.stringify({ identifier: 'Hello' })
 						);
 						elem = fixture('basic');
-						expect(elem.timezoneIdentifier).to.equal('Hello');
+						expect(elem.getTimezone().identifier).to.equal('Hello');
 					});
 
 					it('should not fail if timezone data is missing', function() {
 						elem = fixture('basic');
-						expect(elem.__timezone).to.equal('');
-						expect(elem.timezoneIdentifier).to.equal('');
+						expect(elem.getTimezone().name).to.equal('');
+						expect(elem.getTimezone().identifier).to.equal('');
 					});
 
 					it('should not fail if timezone data is invalid', function() {
 						htmlElem.setAttribute('data-timezone', '{ohno;:}');
 						elem = fixture('basic');
-						expect(elem.__timezone).to.equal('');
-						expect(elem.timezoneIdentifier).to.equal('');
+						expect(elem.getTimezone().name).to.equal('');
+						expect(elem.getTimezone().identifier).to.equal('');
 					});
 
 					it('should update timezone if "data-timezone" changes', function(done) {
 						elem = fixture('basic');
 						elem.addEventListener('d2l-localize-behavior-timezone-changed', function() {
-							expect(elem.__timezone).to.equal('foo');
-							expect(elem.timezoneIdentifier).to.equal('bar');
+							expect(elem.getTimezone().name).to.equal('foo');
+							expect(elem.getTimezone().identifier).to.equal('bar');
 							done();
 						});
 						htmlElem.setAttribute(

--- a/test/d2l-localize-behavior.html
+++ b/test/d2l-localize-behavior.html
@@ -393,26 +393,38 @@
 						expect(elem.__timezone).to.equal('Hello');
 					});
 
+					it('should return timezone\'s identifier', function () {
+						htmlElem.setAttribute(
+							'data-timezone',
+							JSON.stringify({ identifier: 'Hello' })
+						);
+						elem = fixture('basic');
+						expect(elem.timezoneIdentifier).to.equal('Hello');
+					});
+
 					it('should not fail if timezone data is missing', function() {
 						elem = fixture('basic');
 						expect(elem.__timezone).to.equal('');
+						expect(elem.timezoneIdentifier).to.equal('');
 					});
 
 					it('should not fail if timezone data is invalid', function() {
 						htmlElem.setAttribute('data-timezone', '{ohno;:}');
 						elem = fixture('basic');
 						expect(elem.__timezone).to.equal('');
+						expect(elem.timezoneIdentifier).to.equal('');
 					});
 
 					it('should update timezone if "data-timezone" changes', function(done) {
 						elem = fixture('basic');
 						elem.addEventListener('d2l-localize-behavior-timezone-changed', function() {
 							expect(elem.__timezone).to.equal('foo');
+							expect(elem.timezoneIdentifier).to.equal('bar');
 							done();
 						});
 						htmlElem.setAttribute(
 							'data-timezone',
-							JSON.stringify({ name: 'foo' })
+							JSON.stringify({ name: 'foo', identifier: 'bar' })
 						);
 					});
 

--- a/test/d2l-localize-behavior.html
+++ b/test/d2l-localize-behavior.html
@@ -393,7 +393,7 @@
 						expect(elem.__timezone).to.equal('Hello');
 					});
 
-					it('should return timezone\'s identifier', function () {
+					it('should return timezone\'s identifier', function() {
 						htmlElem.setAttribute(
 							'data-timezone',
 							JSON.stringify({ identifier: 'Hello' })


### PR DESCRIPTION
To allow other components to see the LMS timezone _identifier_ (currently only the _name_ is available in `__timezone`). Needed by d2l-datetime-picker so that timezone can be set consistently, rather than "guessing" the way it currently does (https://github.com/BrightspaceUI/datetime-picker/blob/master/d2l-datetime-picker.html#L237), which can create inconsistencies (see https://trello.com/c/hqnjqI83/25-assignment-due-date-time-not-accounting-for-timezone-properly). 