### PR TITLE
Use core

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Bower version][bower-image]][bower-url]
 [![Build status][ci-image]][ci-url]
 
-[Polymer](https://www.polymer-project.org) mixin wrapper around [app-localize-behavior](https://github.com/PolymerElements/app-localize-behavior), adding automatic language resolution, timezone and locale overrides support.
+[Polymer](https://www.polymer-project.org) mixin for localization of text, dates, times, numbers and file sizes. Also supports automatic language resolution, timezone and locale overrides.
 
 For further information on this and other components, refer to [The Brightspace UI Guide](https://github.com/BrightspaceUI/guide/wiki).
 
@@ -16,52 +16,37 @@ bower install d2l-localize-behavior
 
 ## Usage
 
-Use this mixin in your web components the same way [app-localize-behavior](https://github.com/PolymerElements/app-localize-behavior) is used. Place your language resources as a collection property called `resources`. Unlike `app-localize-behavior`, don't specify a `language` property as it will be resolved automatically.
+Place your language resources as a collection property called `resources`.
 
-```html
-<link rel="import" href="bower_components/d2l-localize-behavior/d2l-localize-behavior.html">
-<dom-module id="my-elem">
-  <template strip-whitespace>
-    <p>{{localize('hello')}}</p>
-  </template>
-  <script>
-    Polymer({
-      is: 'my-elem',
-      behaviors: [
-        D2L.PolymerBehaviors.LocalizeBehavior
-      ],
-      properties: {
-        resources: {
-          value: function() {
-            return {
-              'de': { 'hello': 'Hallo' },
-              'en': { 'hello': 'Hello' },
-              'en-ca': { 'hello': 'Hello, eh' },
-              'es': { 'hello': 'Hola' },
-              'fr': { 'hello': 'Bonjour' }
-            };
-          }
+```javascript
+import 'd2l-localize-behavior/d2l-localize-behavior.js';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
+
+class MyElement extends mixinBehaviors([
+  D2L.PolymerBehaviors.LocalizeBehavior
+]), PolymerElement) {
+
+  static get template() {
+    return html`<p>{{localize('hello')}}</p>`;
+  }
+
+  static get properties() {
+    return {
+      resources: {
+        value: function() {
+          return {
+            'de': { 'hello': 'Hallo' },
+            'en': { 'hello': 'Hello' },
+            'en-ca': { 'hello': 'Hello, eh' },
+            'es': { 'hello': 'Hola' },
+            'fr': { 'hello': 'Bonjour' }
+          };
         }
       }
-    });
-  </script>
-</dom-module>
+    }
+  }
+}
 ```
-
-Then consume your web component in a page which has the `lang` attribute set on the `<html>` element:
-
-```html
-<html lang="fr">
-  <head>
-    <link rel="import" href="my-elem.html">
-  </head>
-  <body>
-    <my-elem></my-elem>
-  </body>
-</html>
-```
-
-If the language of the page changes (via an update to the `lang` attribute on `<html>`), the mixin will automatically detect the change and re-render the web component. It will fire the event `d2l-localize-behavior-language-changed` when this occurs.
 
 ### Language Resources
 
@@ -184,10 +169,6 @@ time.formatFileSize(1234567.89);
 The user's language, timezone and any D2L locale overrides are automatically fetched by `d2l-localize-behavior` from the `<html>` element's `lang`, `data-timezone` and `data-intl-overrides` attributes respectively.
 
 These attributes are set automatically by pages in the monolith, and will also be automatically set in IFRAME'd Free-Range Apps (and kept in sync) by [ifrau](https://github.com/Brightspace/ifrau).
-
-## Future Enhancements
-
-* Ability to "merge" regional and base language values such that only regional overrides would be required
 
 ## Developing, Testing and Contributing
 

--- a/demo/behavior-component.js
+++ b/demo/behavior-component.js
@@ -5,14 +5,14 @@ const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<dom-module id="d2l-behavior-component">
 	<template strip-whitespace="">
-		<p>Text: [[localize('hello')]]</p>
+		<p>Text: [[localize('hello', 'name', 'Bill')]]</p>
 		<p>Number: [[formatNumber(123456.789)]]</p>
 		<p>Date: [[formatDate(date)]]</p>
 		<p>Time: [[formatTime(date)]]</p>
 		<p>Date &amp; time: [[formatDateTime(date)]]</p>
 		<p>File size: [[formatFileSize(123456789)]]</p>
 	</template>
-	
+
 </dom-module>`;
 
 document.head.appendChild($_documentContainer.content);
@@ -29,19 +29,19 @@ Polymer({
 		resources: {
 			value: function() {
 				return {
-					'ar': { 'hello': 'مرحبا' },
-					'de': { 'hello': 'Hallo' },
-					'en': { 'hello': 'Hello' },
-					'en-CA': { 'hello': 'Hello, eh' },
-					'es': { 'hello': 'Hola' },
-					'fr': { 'hello': 'Bonjour' },
-					'ja': { 'hello': 'こんにちは' },
-					'ko': { 'hello': '안녕하세요' },
-					'pt-BR': { 'hello': 'Olá' },
-					'sv': { 'hello': 'Hallå' },
-					'tr': { 'hello': 'Merhaba' },
-					'zh-CN': { 'hello': '你好' },
-					'zh-TW': { 'hello': '你好' }
+					'ar': { 'hello': 'مرحبا {name}' },
+					'de': { 'hello': 'Hallo {name}' },
+					'en': { 'hello': 'Hello {name}' },
+					'en-CA': { 'hello': 'Hello,  {name} eh' },
+					'es': { 'hello': 'Hola {name}' },
+					'fr': { 'hello': 'Bonjour {name}' },
+					'ja': { 'hello': 'こんにちは {name}' },
+					'ko': { 'hello': '안녕하세요 {name}' },
+					'pt-BR': { 'hello': 'Olá {name}' },
+					'sv': { 'hello': 'Hallå {name}' },
+					'tr': { 'hello': 'Merhaba {name}' },
+					'zh-CN': { 'hello': '你好 {name}' },
+					'zh-TW': { 'hello': '你好 {name}' }
 				};
 			}
 		}

--- a/demo/index.html
+++ b/demo/index.html
@@ -3,49 +3,17 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
-		<title>d2l-localize-behavior</title>
-		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
-		<script type="module" src="../../@polymer/iron-demo-helpers/demo-pages-shared-styles.js"></script>
-		<script type="module" src="../../@polymer/iron-demo-helpers/demo-snippet.js"></script>
-		<script type="module" src="./behavior-component.js"></script>
-		<!-- FIXME(polymer-modulizer):
-		These imperative modules that innerHTML your HTML are
-		a hacky way to be sure that any mixins in included style
-		modules are ready before any elements that reference them are
-		instantiated, otherwise the CSS @apply mixin polyfill won't be
-		able to expand the underlying CSS custom properties.
-		See: https://github.com/Polymer/polymer-modulizer/issues/154
-		-->
-	<script type="module">
-const $_documentContainer = document.createElement('template');
-
-$_documentContainer.innerHTML = `<custom-style>
-			<style is="custom-style" include="demo-pages-shared-styles"></style>
-		</custom-style>`;
-
-document.body.appendChild($_documentContainer.content);
-</script>
+		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
-const $_documentContainer = document.createElement('template');
-
-$_documentContainer.innerHTML = `<style>
-			html {
-				color: #565a5c;
-				font-family: verdana;
-				font-size: 20px;
-			}
-			</style>`;
-
-document.body.appendChild($_documentContainer.content);
-</script>
+			import '/node_modules/@brightspace-ui/core/components/demo/demo-page.js';
+			import './behavior-component.js';
+		</script>
 	</head>
 	<body unresolved>
-		<script type="module">
-const $_documentContainer = document.createElement('template');
+		<d2l-demo-page page-title="d2l-localize-behavior">
 
-$_documentContainer.innerHTML = `<div class="vertical-section-container centered">
-
-			<h3>Behavior (Hybrid)</h3>
+			<h2>Behavior (Hybrid)</h2>
 			<div style="margin-bottom: 1rem;">
 				<label>Language:
 					<select id="langSwitcher">
@@ -65,25 +33,17 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 					</select>
 				</label>
 			</div>
-			<demo-snippet>
-				<template>
-					<d2l-behavior-component></d2l-behavior-component>
-				</template>
-			</demo-snippet>
-		</div>`;
-
-document.body.appendChild($_documentContainer.content);
-</script>
-		<script type="module">
-import '@polymer/iron-demo-helpers/demo-pages-shared-styles.js';
-import '@polymer/iron-demo-helpers/demo-snippet.js';
-import './behavior-component.js';
-var langSwitcher = document.getElementById('langSwitcher');
-function updateLang() {
-	var value = langSwitcher.options[langSwitcher.selectedIndex].value;
-	document.documentElement.setAttribute('lang', value);
-}
-langSwitcher.addEventListener('change', updateLang);
-</script>
+			<d2l-demo-snippet>
+				<d2l-behavior-component></d2l-behavior-component>
+			</d2l-demo-snippet>
+		</d2l-demo-page>
+		<script>
+			var langSwitcher = document.getElementById('langSwitcher');
+			function updateLang() {
+				var value = langSwitcher.options[langSwitcher.selectedIndex].value;
+				document.documentElement.setAttribute('lang', value);
+			}
+			langSwitcher.addEventListener('change', updateLang);
+		</script>
 	</body>
 </html>

--- a/package.json
+++ b/package.json
@@ -41,5 +41,6 @@
     "@polymer/app-localize-behavior": "^3.0.0-pre.18",
     "@polymer/polymer": "^3.0.0",
     "d2l-intl": "^2.0.0"
+    "@brightspace-ui/core": "^1",
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,18 +16,16 @@
   "author": "D2L Corporation",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@babel/polyfill": "^7.0.0",
-    "@polymer/iron-component-page": "^3.0.0-pre.18",
-    "@polymer/iron-demo-helpers": "^3.0.0-pre.18",
-    "@polymer/iron-test-helpers": "^3.0.0-pre.18",
-    "@webcomponents/webcomponentsjs": "^2.2.1",
-    "babel-eslint": "^10.0.1",
-    "eslint": "^4.15.0",
-    "eslint-config-brightspace": "^0.4.0",
-    "eslint-plugin-html": "^4.0.1",
-    "frau-ci": "^1.33.2",
-    "polymer-cli": "^1.9.1",
-    "wct-browser-legacy": "^1.0.1"
+    "@babel/polyfill": "^7",
+    "@webcomponents/webcomponentsjs": "^2",
+    "babel-eslint": "^10",
+    "eslint": "^6",
+    "eslint-config-brightspace": "^0.6",
+    "eslint-plugin-html": "^6",
+    "eslint-plugin-sort-class-members": "^1",
+    "frau-ci": "^1",
+    "polymer-cli": "^1",
+    "wct-browser-legacy": "^1"
   },
   "version": "2.5.0",
   "resolutions": {
@@ -38,9 +36,7 @@
   },
   "main": "d2l-localize-behavior.js",
   "dependencies": {
-    "@polymer/app-localize-behavior": "^3.0.0-pre.18",
-    "@polymer/polymer": "^3.0.0",
-    "d2l-intl": "^2.0.0"
     "@brightspace-ui/core": "^1",
+    "@polymer/polymer": "^3"
   }
 }

--- a/test/d2l-localize-behavior.html
+++ b/test/d2l-localize-behavior.html
@@ -11,7 +11,6 @@
 		<script type="module" src="../d2l-localize-behavior.js"></script>
 	</head>
 	<body>
-		<test-elem></test-elem>
 		<test-fixture id="basic">
 			<template>
 				<test-elem></test-elem>
@@ -416,20 +415,6 @@ describe('d2l-localize-behavior', function() {
 			elem = fixture('basic');
 			expect(elem.getTimezone().name).to.equal('');
 			expect(elem.getTimezone().identifier).to.equal('');
-		});
-
-		it('should update timezone if "data-timezone" changes', function(done) {
-			elem = fixture('basic');
-			elem.addEventListener('d2l-localize-behavior-timezone-changed', function() {
-				expect(elem.getTimezone().name).to.equal('foo');
-				expect(elem.getTimezone().identifier).to.equal('bar');
-				done();
-			});
-			htmlElem.setAttribute(
-				'data-timezone',
-				JSON.stringify({ name: 'foo', identifier: 'bar' })
-
-			);
 		});
 
 	});


### PR DESCRIPTION
Using the refactored localization code from core, eliminating a lot of duplication. Also removes dependency on `app-localize-behavior`. 🎉 

Since core doesn't expose an event for changes in the timezone (intentionally), I've stopped handling that here. It's a weird edge case that won't happen in the browser anyway. I'll be [adjusting datetime-picker's usage of it](https://github.com/BrightspaceUI/datetime-picker/blob/master/d2l-datetime-picker.js#L300) in another PR.