### PR TITLE
resolving computed properties immediately

### DIFF
--- a/d2l-localize-behavior.js
+++ b/d2l-localize-behavior.js
@@ -14,23 +14,23 @@ D2L.PolymerBehaviors.LocalizeBehaviorImpl = {
 	properties: {
 		formatDateTime: {
 			type: Function,
-			computed: '_computeFormatDateTime(language)'
+			computed: '_computeFormatDateTime(language, __resolveFast)'
 		},
 		formatDate: {
 			type: Function,
-			computed: '_computeFormatDate(language)'
+			computed: '_computeFormatDate(language, __resolveFast)'
 		},
 		formatFileSize: {
 			type: Function,
-			computed: '_computeFormatFileSize(language)'
+			computed: '_computeFormatFileSize(language, __resolveFast)'
 		},
 		formatNumber: {
 			type: Function,
-			computed: '_computeFormatNumber(language)'
+			computed: '_computeFormatNumber(language, __resolveFast)'
 		},
 		formatTime: {
 			type: Function,
-			computed: '_computeFormatTime(language)'
+			computed: '_computeFormatTime(language, __resolveFast)'
 		},
 		language: {
 			type: String,
@@ -38,15 +38,15 @@ D2L.PolymerBehaviors.LocalizeBehaviorImpl = {
 		},
 		parseDate: {
 			type: Function,
-			computed: '_computeParseDate(language)'
+			computed: '_computeParseDate(language, __resolveFast)'
 		},
 		parseNumber: {
 			type: Function,
-			computed: '_computeParseNumber(language)'
+			computed: '_computeParseNumber(language, __resolveFast)'
 		},
 		parseTime: {
 			type: Function,
-			computed: '_computeParseTime(language)'
+			computed: '_computeParseTime(language, __resolveFast)'
 		},
 		__documentLanguage: {
 			type: String,
@@ -62,6 +62,15 @@ D2L.PolymerBehaviors.LocalizeBehaviorImpl = {
 		},
 		__languageChangeCallback: {
 			type: Object
+		},
+		/*
+		 * Required so that the format/parse computed functions resolve
+		 * immediately and become defined. Otherwise they won't be defined if
+		 * another component's computed property that calls them.
+		 */
+		__resolveFast: {
+			type: Boolean,
+			value: true
 		}
 	},
 	observers: [

--- a/demo/test-elem.js
+++ b/demo/test-elem.js
@@ -22,6 +22,11 @@ Polymer({
 		D2L.PolymerBehaviors.LocalizeBehavior
 	],
 	properties: {
+		computed: {
+			type: String,
+			value: '',
+			computed: '_getComputedText(name)'
+		},
 		date: {
 			type: Date,
 			value: new Date()
@@ -48,5 +53,8 @@ Polymer({
 				};
 			}
 		}
+	},
+	_getComputedText: function(name) {
+		return `${this.formatNumber(5.2)}-${name}`;
 	}
 });


### PR DESCRIPTION
@maboelsoudd2l noticed that with the recent changes to `localize-behavior`, a component in `facet-filter-sort` has started blowing up with `formatNumber` is undefined errors.

What was going on: previously, these format/parse computed properties (really they're functions that we want to re-evaluate when the language changes) were passed `__overrides`. That's no longer required since the underlying core function handles that now. But the removal of that parameter causes `formatNumber` (and the others) to not be defined until later.

Why? It's due to how Polymer computed properties work. They remain `undefined` until at least one of their parameters is defined. So in this case, they all depend on `language`, which may not be defined immediately. When `__overrides` was passed in, it was defined right away so the property got defined.

Good stuff.