### PR TITLE
using fork of app-localize-behavior to pick up intl-messageformat v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "main": "d2l-localize-behavior.js",
   "dependencies": {
     "@brightspace-ui/intl": "^3",
-    "@polymer/app-localize-behavior": "^3.0.1",
+    "@polymer/app-localize-behavior": "BrightspaceUI/app-localize-behavior#v3.0.1-d2l",
     "@polymer/polymer": "^3"
   }
 }


### PR DESCRIPTION
This upgrades us to the latest and ES6 module friendly version of `intl-messageformat`. Will need to work with a change in `@brightspace-ui/core` as well.

There are 5 places that also reference `app-localize-behavior`, which will either need to stop referencing it, be converted to `d2l-localize-behavior` or point at the fork as well:
- [manager-view-fra](https://github.com/Brightspace/manager-view-fra/blob/70577bf6b7dd4999c0b87b87e85627e1ac85157d/package.json#L77)
- [d2l-activity-details-ui](https://github.com/Brightspace/d2l-activity-details-ui/blob/3d616ea18b625f7eec60cc3b0a592ad538e9d180/package.json#L42) ([pull request to use fork](https://github.com/Brightspace/d2l-activity-details-ui/pull/130) -> merged)
- [d2l-recent-grades-ui](https://github.com/Brightspace/d2l-recent-grades-ui/blob/f5fed7f8c4cc835e0ee396d537ad96b1752a5098/package.json#L60) (doesn't need it, [PR to remove](https://github.com/Brightspace/d2l-recent-grades-ui/pull/129) -> merged)
- [user-switcher](https://github.com/Brightspace/user-switcher/blob/102fda6f254d10f7366d863bf543d0674815f754/package.json#L50) ([pull request to use fork](https://github.com/Brightspace/user-switcher/pull/51) -> merged)
- [d2l-richtext-parent](https://github.com/Brightspace/d2l-richtext-parent/blob/69d01b81d463f75b61fbfd0a5c397188d007ec77/package.json#L47) ([pull request to use fork](https://github.com/Brightspace/d2l-richtext-parent/pull/19) -> merged)