### PR TITLE
catching errors thrown from intlmessage-format

### DIFF
--- a/app-localize-behavior.js
+++ b/app-localize-behavior.js
@@ -289,7 +289,14 @@ export const AppLocalizeBehavior = {
         args[arguments[i]] = arguments[i + 1];
       }
 
-      return translatedMessage.format(args);
+      var formattedMessage = translatedValue;
+      try {
+        formattedMessage = translatedMessage.format(args);
+      } catch (e) {
+        console.error(e);
+      }
+      return formattedMessage;
+
     }.bind(this);
   },
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "polymer-cli": "^1",
     "wct-browser-legacy": "^1"
   },
-  "version": "2.5.6",
+  "version": "2.5.7",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",

--- a/test/d2l-localize-behavior.html
+++ b/test/d2l-localize-behavior.html
@@ -176,8 +176,14 @@ describe('d2l-localize-behavior', function() {
 
 	describe('localize', function() {
 
+		let errorSpy;
 		beforeEach(function() {
 			elem = fixture('en-ca');
+			errorSpy = sinon.stub(console, 'error');
+		});
+
+		afterEach(() => {
+			errorSpy.restore();
 		});
 
 		it('should localize text', function() {
@@ -195,6 +201,17 @@ describe('d2l-localize-behavior', function() {
 				done();
 			});
 			documentLocaleSettings.language = 'fr';
+		});
+
+		it('should not throw when a parameter is missing', () => {
+			let val;
+			expect(() => {
+				val = elem.localize('hello', 'invalidParam', 'Bill');
+			}).to.not.throw();
+			expect(val).to.equal('Hello {name}');
+			const errArg = errorSpy.firstCall.args[0];
+			expect(errArg).to.be.instanceof(Error);
+			expect(errArg.message).to.equal('The intl string context variable "name" was not provided to the string "Hello {name}"');
 		});
 
 	});


### PR DESCRIPTION
Mirroring the [change made to core](https://github.com/BrightspaceUI/core/pull/387) to catch errors thrown from `intl-messageformat` when parameters are missing.