### PR TITLE
GAUD-9816: add eslint-config-brightspace to ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+    - dependency-name: "eslint-config-brightspace"
+      # polymer-3-config was removed in 1.0.0
+      versions: ">=0.25.0"


### PR DESCRIPTION
This needs to stick on the old version as we removed the `polymer-3-config` in v1.